### PR TITLE
Use native namespace packages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+2.0
+===
+
+- Keyrings namespace package has switched from pkg_resources
+  to pkgutil for native namespace package support.
+
 1.0
 ===
 

--- a/keyrings/__init__.py
+++ b/keyrings/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup_params = dict(
     license = 'MIT',
     packages = setuptools.find_packages(exclude=['tests']),
     include_package_data = True,
-    namespace_packages = name.split('.')[:-1],
     install_requires = [
         'argon2_cffi',
         'keyring',


### PR DESCRIPTION
In keyrings.alt 3.0, I've changed the `keyrings` package to use the [native](https://packaging.python.org/guides/packaging-namespace-packages/#native-namespace-packages) technique for namespace packages. This change should happen in a coordinated fashion across all packages using the namespace, so I'm making that recommendation here. Making this change will keep it compatible with keyrings.alt 3.0.

Although I've indicated this change as a major bump to 2.0, I don't expect it to have a major effect except to improve compatibility with environments where both keyrings.alt and keyrings.cryptfile are install (which I expect to be rare), so feel free to use a smaller bump at your discretion.