### PR TITLE
Compatibility with keyring 15

### DIFF
--- a/keyrings/cryptfile/_escape.py
+++ b/keyrings/cryptfile/_escape.py
@@ -10,12 +10,6 @@ https://github.com/jaraco/keyring/blob/master/CHANGES.rst#1500
 import re
 import string
 import sys
-import warnings
-
-warnings.warn(
-    "escape is deprecated and will be removed",
-    DeprecationWarning,
-)
 
 # True if we are running on Python 3.
 # taken from six.py

--- a/keyrings/cryptfile/_escape.py
+++ b/keyrings/cryptfile/_escape.py
@@ -1,0 +1,70 @@
+"""
+escape/unescape routines available for backends which need
+alphanumeric usernames, services, or other values
+
+Originally provided by the keyring module, these escape utility
+routines have been removed from it in version 15.0.0, see
+https://github.com/jaraco/keyring/blob/master/CHANGES.rst#1500
+"""
+
+import re
+import string
+import sys
+import warnings
+
+warnings.warn(
+    "escape is deprecated and will be removed",
+    DeprecationWarning,
+)
+
+# True if we are running on Python 3.
+# taken from six.py
+PY3 = sys.version_info[0] == 3
+
+# allow use of unicode literals
+if PY3:
+    def u(s):
+        return s
+else:
+    def u(s):
+        return s.decode('utf-8')
+
+_unichr = chr if PY3 else unichr  # noqa: F821
+
+LEGAL_CHARS = (
+    getattr(string, 'letters', None)  # Python 2
+    or getattr(string, 'ascii_letters')  # Python 3
+) + string.digits
+
+ESCAPE_FMT = "_%02X"
+
+
+def _escape_char(c):
+    "Single char escape. Return the char, escaped if not already legal"
+    if isinstance(c, int):
+        c = _unichr(c)
+    return c if c in LEGAL_CHARS else ESCAPE_FMT % ord(c)
+
+
+def escape(value):
+    """
+    Escapes given string so the result consists of alphanumeric chars and
+    underscore only.
+    """
+    return "".join(_escape_char(c) for c in value.encode('utf-8'))
+
+
+def _unescape_code(regex_match):
+    ordinal = int(regex_match.group('code'), 16)
+    return bytes([ordinal]) if PY3 else chr(ordinal)
+
+
+def unescape(value):
+    """
+    Inverse of escape.
+    """
+    pattern = ESCAPE_FMT.replace('%02X', '(?P<code>[0-9A-Fa-f]{2})')
+    # the pattern must be bytes to operate on bytes
+    pattern_bytes = pattern.encode('ascii')
+    re_esc = re.compile(pattern_bytes)
+    return re_esc.sub(_unescape_code, value.encode('ascii')).decode('utf-8')

--- a/keyrings/cryptfile/convert.py
+++ b/keyrings/cryptfile/convert.py
@@ -10,9 +10,9 @@ import argparse
 log = logging.getLogger('convert')
 
 from keyring.py27compat import configparser
-from keyring.util.escape import escape, unescape
 
 from keyrings.cryptfile.cryptfile import CryptFileKeyring
+from keyrings.cryptfile._escape import escape, unescape
 
 NOTE = """\
 Note: no effort has been made to replace the original keyring file.

--- a/keyrings/cryptfile/cryptfile.py
+++ b/keyrings/cryptfile/cryptfile.py
@@ -5,10 +5,10 @@ import json
 
 from keyring.py27compat import configparser
 from keyring.util import properties
-from keyring.util.escape import escape as escape_for_ini
 
 from keyrings.cryptfile.file import EncryptedKeyring
 from keyrings.cryptfile.file_base import decodebytes, encodebytes
+from keyrings.cryptfile._escape import escape as escape_for_ini
 
 __version__ = '1.0'
 

--- a/keyrings/cryptfile/file.py
+++ b/keyrings/cryptfile/file.py
@@ -8,11 +8,11 @@ import getpass
 from keyring.py27compat import configparser
 
 from keyring.util import properties
-from keyring.util.escape import escape as escape_for_ini
 
 from keyrings.cryptfile.file_base import (
         Keyring, decodebytes, encodebytes,
 )
+from keyrings.cryptfile._escape import escape as escape_for_ini
 
 class PlaintextKeyring(Keyring):
     """Simple File Keyring with no encryption"""

--- a/keyrings/cryptfile/file_base.py
+++ b/keyrings/cryptfile/file_base.py
@@ -9,7 +9,8 @@ from keyring.py27compat import configparser
 from keyring.errors import PasswordDeleteError
 from keyring.backend import KeyringBackend
 from keyring.util import platform_, properties
-from keyring.util.escape import escape as escape_for_ini
+
+from keyrings.cryptfile._escape import escape as escape_for_ini
 
 try:
     encodebytes = base64.encodebytes

--- a/tests/test_cryptfile.py
+++ b/tests/test_cryptfile.py
@@ -4,9 +4,8 @@ from unittest import mock
 
 from .test_file import FileKeyringTests
 
-from keyring.util.escape import escape as escape_for_ini
-
 from keyrings.cryptfile import cryptfile
+from keyrings.cryptfile._escape import escape as escape_for_ini
 
 def is_crypto_supported():
     try:

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -11,10 +11,10 @@ from keyring.tests.test_backend import BackendBasicTests
 from keyring.tests.util import random_string
 
 from keyring.py27compat import configparser
-from keyring.util.escape import escape as escape_for_ini
 
 from keyrings.cryptfile import file
 from keyrings.cryptfile.file_base import encodebytes
+from keyrings.cryptfile._escape import escape as escape_for_ini
 
 from keyring.errors import PasswordDeleteError
 


### PR DESCRIPTION
The `keyring.utils.escape` module was deprecated in `keyring` [`12.2.0`](https://github.com/jaraco/keyring/blob/master/CHANGES.rst#1220) and finally removed in [`15.0.0`](https://github.com/jaraco/keyring/blob/master/CHANGES.rst#1500).

As `keyrings.cryptfile` seemingly heavily relies on this module, its current version (`1.2.1`) is incompatible with `keyring` >= `15.0.0`.

With this pull request, the deprecated module is copied into this project to resolve the incompatibility issue. Besides removal of the deprecation notice the module has not been modified.

The original code can be found here: https://github.com/jaraco/keyring/blob/13.2.1/keyring/util/escape.py