### PR TITLE
Remove py2.7 compatibility for keyring>=19.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.3.4
+=====
+- remove support for Python 2.7 and keyring versions prior to 19.0.0
+
 1.3.3
 =====
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ data as well as its reference (service/userid).
 Quick start guide
 -----------------
 
-In order to get you started, you will need to have a `python2/python3` environment
+In order to get you started, you will need to have a `python3` environment
 and `git` available (preferably on a linux system).
 
 You might want to provide the python packages [argon2-cffi](https://pypi.python.org/pypi/argon2_cffi), [keyring](https://pypi.python.org/pypi/keyring), [pycryptodome](https://pypi.python.org/pypi/pycryptodome)

--- a/keyrings/cryptfile/__init__.py
+++ b/keyrings/cryptfile/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '1.3.4dev'
+__version__ = '1.3.4'

--- a/keyrings/cryptfile/__init__.py
+++ b/keyrings/cryptfile/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '1.3.3'
+__version__ = '1.3.4dev'

--- a/keyrings/cryptfile/convert.py
+++ b/keyrings/cryptfile/convert.py
@@ -9,7 +9,7 @@ import argparse
 
 log = logging.getLogger('convert')
 
-from keyring.py27compat import configparser
+import configparser
 
 from keyrings.cryptfile.cryptfile import CryptFileKeyring
 from keyrings.cryptfile._escape import escape, unescape

--- a/keyrings/cryptfile/cryptfile.py
+++ b/keyrings/cryptfile/cryptfile.py
@@ -3,7 +3,7 @@ from __future__ import with_statement
 import os
 import json
 
-from keyring.py27compat import configparser
+import configparser
 from keyring.util import properties
 
 from keyrings.cryptfile import __version__ as version

--- a/keyrings/cryptfile/file.py
+++ b/keyrings/cryptfile/file.py
@@ -5,7 +5,7 @@ import sys
 import json
 import getpass
 
-from keyring.py27compat import configparser
+import configparser
 
 from keyring.util import properties
 

--- a/keyrings/cryptfile/file_base.py
+++ b/keyrings/cryptfile/file_base.py
@@ -4,7 +4,7 @@ import os
 import abc
 import base64
 
-from keyring.py27compat import configparser
+import configparser
 
 from keyring.errors import PasswordDeleteError
 from keyring.backend import KeyringBackend

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,10 @@ setup_params = dict(
     license = 'MIT',
     packages = setuptools.find_packages(exclude=['tests']),
     include_package_data = True,
-    python_requires = '>=2.7',
+    python_requires = '>=3.5',
     install_requires = [
         'argon2_cffi',
-        'keyring',
+        'keyring>=19.0.0',
         'pycryptodome',
     ],
     extras_require = {},
@@ -37,11 +37,9 @@ setup_params = dict(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7'
     ],
     entry_points = {
         'keyring.backends': [

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -10,7 +10,7 @@ from unittest import mock
 from keyring.tests.test_backend import BackendBasicTests
 from keyring.tests.util import random_string
 
-from keyring.py27compat import configparser
+import configparser
 
 from keyrings.cryptfile import file
 from keyrings.cryptfile.file_base import encodebytes


### PR DESCRIPTION
Three days ago, in version 19.0.0, the keyring project dropped support for Python 2.7, and therefore the py27compat module where keyrings.cryptfile had been getting configparser from. This PR makes keyrings.cryptfile import configparser directly and depend on keyring>=19.0.0, fixing the ``ImportError``.

I've provisionally incremented the micro version number, but this might be considered a major release, so right now I have it as version 1.3.4dev. Please change this as you see fit.