### PR TITLE
cancel existing pr runs when new are started

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ on:
     # Daily at 05:47
     - cron: '47 5 * * *'
 
+concurrency:
+  # SHA is added to the end if on `master` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ (github.ref == 'refs/heads/master') && github.sha || '' }}
+  cancel-in-progress: true
+
 env:
   PIP_NO_PYTHON_VERSION_WARNING: 1
 


### PR DESCRIPTION
This is just to save some CI time since user accounts don't get a lot of parallel runners.