### PR TITLE
Modified so that underscore is a LEGAL_CHARS character.

### DIFF
--- a/keyrings/cryptfile/escape.py
+++ b/keyrings/cryptfile/escape.py
@@ -9,7 +9,7 @@ import string
 LEGAL_CHARS = (
     getattr(string, 'letters', None)  # Python 2
     or getattr(string, 'ascii_letters')  # Python 3
-) + string.digits
+) + string.digits + "_"
 
 ESCAPE_FMT = "_%02X"
 


### PR DESCRIPTION
The escape method description implies that underscores are an acceptable character not requiring an escape. During testing this was not the case. 

I modified the code so that an underscore is a LEGAL_CHAR and thus would not be escaped.